### PR TITLE
make winctl compatible with electron v20 and above

### DIFF
--- a/src/WinCtlWindow.cc
+++ b/src/WinCtlWindow.cc
@@ -13,7 +13,7 @@ Window::Window(HWND handle) {
 Window::~Window() {}
 
 void Window::Init (v8::Local<v8::Object> exports) {
-	v8::Local<v8::Context> context = exports->CreationContext();
+	v8::Local<v8::Context> context = exports->GetCreationContext().ToLocalChecked();
 	Nan::HandleScope scope;
 
 	v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(New);

--- a/src/WinCtlWrap.cc
+++ b/src/WinCtlWrap.cc
@@ -5,7 +5,7 @@ using v8::FunctionTemplate;
 void InitAll(v8::Local<v8::Object> exports) {
 	Window::Init(exports);
 
-	v8::Local<v8::Context> context = exports->CreationContext();
+	v8::Local<v8::Context> context = exports->GetCreationContext().ToLocalChecked();
 	exports->Set(context, Nan::New("GetActiveWindow").ToLocalChecked(), Nan::New<v8::FunctionTemplate>(Window::GetActiveWindow)->GetFunction(context).ToLocalChecked());
 	exports->Set(context, Nan::New("GetWindowByClassName").ToLocalChecked(), Nan::New<v8::FunctionTemplate>(Window::GetWindowByClassName)->GetFunction(context).ToLocalChecked());
 	exports->Set(context, Nan::New("GetWindowByTitleExact").ToLocalChecked(), Nan::New<v8::FunctionTemplate>(Window::GetWindowByTitleExact)->GetFunction(context).ToLocalChecked());


### PR DESCRIPTION
According to various reports there are currently two major issues that cause electron apps (after v20) to conflict with native modules.

1.) deprecated `AccessorSignatures` as per https://github.com/nodejs/nan/pull/943 - This issue is fixed by a fix in the nan module, it hasn't been merged and released yet. I tested it by installing nan from `https://github.com/weedz/nan/commit/a679b69b92e1997f6b40f1d3981a58a0021e1b99` and winctl builds with this patch.

2.) `CreationContext` is no longer supported. According to https://github.com/WiseLibs/better-sqlite3/issues/858#issuecomment-1228218306 this can be fixed by replacing `CreationContext()` with `GetCreationContext().ToLocalChecked()`.

The latter was implemented here. With the upcoming release of a new nan version the first issue should "fix itself" :-) winctl should then be fully compatible with electron v20 and newer.